### PR TITLE
feat: Implement Phase 3 - Cleanup functionality

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -76,8 +76,10 @@ jobs:
 
       - name: Cleanup KECS
         if: always()
-        run: |
-          kecs stop --instance "${{ steps.kecs.outputs.instance-name }}" || true
+        uses: ./cleanup
+        with:
+          instance-name: ${{ steps.kecs.outputs.instance-name }}
+          collect-logs: 'true'
 
   test-custom-config:
     name: Test Custom Configuration
@@ -131,8 +133,10 @@ jobs:
 
       - name: Cleanup KECS
         if: always()
-        run: |
-          kecs stop --instance test-custom || true
+        uses: ./cleanup
+        with:
+          instance-name: test-custom
+          collect-logs: 'true'
 
   test-version-specific:
     name: Test Specific KECS Version
@@ -153,5 +157,7 @@ jobs:
 
       - name: Cleanup KECS
         if: always()
-        run: |
-          kecs stop --instance "${{ steps.kecs.outputs.instance-name }}" || true
+        uses: ./cleanup
+        with:
+          instance-name: ${{ steps.kecs.outputs.instance-name }}
+          collect-logs: 'true'

--- a/README.md
+++ b/README.md
@@ -124,8 +124,24 @@ Always use the cleanup action to ensure resources are properly deleted:
   uses: nandemo-ya/kecs-action/cleanup@v1
   with:
     instance-name: ${{ steps.kecs.outputs.instance-name }}
-    collect-logs: true  # Optional, default: true
+    collect-logs: 'true'  # Optional, default: false
+    log-directory: '.kecs-logs'  # Optional, default: .kecs-logs
 ```
+
+### Cleanup Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `instance-name` | KECS instance name to cleanup | Yes | - |
+| `collect-logs` | Collect logs before cleanup | No | `false` |
+| `log-directory` | Directory to save logs | No | `.kecs-logs` |
+
+When `collect-logs` is enabled, the action will:
+- Collect KECS control plane logs
+- Collect LocalStack logs
+- Collect Traefik logs
+- Collect pod statuses and cluster events
+- Upload logs as workflow artifacts (7-day retention)
 
 ## How It Works
 

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -1,0 +1,37 @@
+name: 'Cleanup KECS'
+description: 'Clean up KECS instance and optionally collect logs'
+branding:
+  icon: 'trash-2'
+  color: 'red'
+
+inputs:
+  instance-name:
+    description: 'KECS instance name to cleanup'
+    required: true
+  collect-logs:
+    description: 'Collect logs before cleanup'
+    required: false
+    default: 'false'
+  log-directory:
+    description: 'Directory to save logs'
+    required: false
+    default: '.kecs-logs'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cleanup KECS Instance
+      shell: bash
+      run: |
+        ${{ github.action_path }}/../scripts/cleanup-kecs.sh \
+          "${{ inputs.instance-name }}" \
+          "${{ inputs.collect-logs }}" \
+          "${{ inputs.log-directory }}"
+
+    - name: Upload Logs
+      if: inputs.collect-logs == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: kecs-logs-${{ inputs.instance-name }}
+        path: ${{ inputs.log-directory }}
+        retention-days: 7

--- a/scripts/cleanup-kecs.sh
+++ b/scripts/cleanup-kecs.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+INSTANCE_NAME="$1"
+COLLECT_LOGS="${2:-false}"
+LOG_DIR="${3:-.kecs-logs}"
+
+if [ -z "$INSTANCE_NAME" ]; then
+  echo "Error: Instance name is required"
+  echo "Usage: $0 <instance-name> [collect-logs] [log-dir]"
+  exit 1
+fi
+
+echo "Cleaning up KECS instance: $INSTANCE_NAME"
+
+# Collect logs if requested
+if [ "$COLLECT_LOGS" = "true" ]; then
+  echo "Collecting logs to $LOG_DIR..."
+  mkdir -p "$LOG_DIR"
+
+  # Get kubectl config
+  export KUBECONFIG="/tmp/kecs-${INSTANCE_NAME}.kubeconfig"
+
+  if [ -f "$KUBECONFIG" ]; then
+    # Collect KECS system logs
+    echo "Collecting KECS system pod logs..."
+    kubectl logs -n kecs-system -l app=kecs --tail=1000 > "$LOG_DIR/kecs-controlplane.log" 2>&1 || true
+    kubectl logs -n kecs-system -l app=localstack --tail=1000 > "$LOG_DIR/localstack.log" 2>&1 || true
+    kubectl logs -n kecs-system -l app.kubernetes.io/name=traefik --tail=1000 > "$LOG_DIR/traefik.log" 2>&1 || true
+
+    # Collect all pod statuses
+    echo "Collecting pod statuses..."
+    kubectl get pods --all-namespaces -o wide > "$LOG_DIR/pods.txt" 2>&1 || true
+
+    # Collect events
+    echo "Collecting cluster events..."
+    kubectl get events --all-namespaces --sort-by='.lastTimestamp' > "$LOG_DIR/events.txt" 2>&1 || true
+
+    echo "✅ Logs collected to $LOG_DIR"
+  else
+    echo "⚠️  Kubeconfig not found at $KUBECONFIG, skipping log collection"
+  fi
+fi
+
+# Stop the KECS instance
+echo "Stopping KECS instance..."
+if command -v kecs &> /dev/null; then
+  kecs stop --instance "$INSTANCE_NAME" || {
+    echo "⚠️  Failed to stop instance cleanly, attempting force cleanup..."
+    # Try k3d directly if kecs stop fails
+    if command -v k3d &> /dev/null; then
+      k3d cluster delete "kecs-$INSTANCE_NAME" || true
+    fi
+  }
+else
+  echo "⚠️  KECS CLI not found, skipping instance stop"
+fi
+
+# Clean up kubeconfig file
+KUBECONFIG_PATH="/tmp/kecs-${INSTANCE_NAME}.kubeconfig"
+if [ -f "$KUBECONFIG_PATH" ]; then
+  rm -f "$KUBECONFIG_PATH"
+  echo "✅ Cleaned up kubeconfig"
+fi
+
+echo "✅ Cleanup completed for instance: $INSTANCE_NAME"


### PR DESCRIPTION
## Overview

This PR implements Phase 3 of kecs-action: Cleanup functionality with optional log collection.

Related: #1 (Phase 3)

## Changes

### New Components

#### Cleanup Action (`cleanup/action.yml`)
- Dedicated composite action for cleanup operations
- Supports optional log collection before cleanup
- Configurable log directory
- Automatic artifact upload for collected logs

#### Cleanup Script (`scripts/cleanup-kecs.sh`)
- **Log Collection**: 
  - KECS control plane logs
  - LocalStack logs
  - Traefik logs
  - Pod statuses across all namespaces
  - Cluster events
- **Instance Cleanup**:
  - Graceful `kecs stop` with fallback
  - Force cleanup with k3d if needed
  - Kubeconfig file cleanup
- **Error Handling**: Continues cleanup even if steps fail

### Updated Files
- **README.md**: Added cleanup action documentation and usage examples
- **test-setup.yml**: All test jobs now use cleanup action with log collection enabled

## Features

✅ **Graceful Cleanup**: Properly stops KECS instances and removes resources
✅ **Log Collection**: Optional collection of system logs for debugging
✅ **Artifact Upload**: Logs automatically uploaded as workflow artifacts (7-day retention)
✅ **Robust**: Fallback mechanisms ensure cleanup completes
✅ **Flexible**: Configurable log directory and collection toggle

## Usage

### Basic Cleanup
```yaml
- name: Cleanup KECS
  if: always()
  uses: nandemo-ya/kecs-action/cleanup@v1
  with:
    instance-name: ${{ steps.kecs.outputs.instance-name }}
```

### With Log Collection
```yaml
- name: Cleanup KECS
  if: always()
  uses: nandemo-ya/kecs-action/cleanup@v1
  with:
    instance-name: ${{ steps.kecs.outputs.instance-name }}
    collect-logs: 'true'
    log-directory: '.kecs-logs'
```

## Inputs

| Input | Description | Required | Default |
|-------|-------------|----------|---------|
| `instance-name` | KECS instance name to cleanup | Yes | - |
| `collect-logs` | Collect logs before cleanup | No | `false` |
| `log-directory` | Directory to save logs | No | `.kecs-logs` |

## Log Collection Details

When `collect-logs: 'true'`, the action collects:
- **Control Plane**: Last 1000 lines of kecs-controlplane logs
- **LocalStack**: Last 1000 lines of localstack logs
- **Traefik**: Last 1000 lines of traefik logs
- **Pod Status**: Current state of all pods
- **Events**: Cluster events sorted by timestamp

All logs are uploaded as workflow artifacts with 7-day retention.

## Testing

All existing test workflows have been updated to use the cleanup action:
- Basic setup test
- Custom configuration test
- Version-specific test

Each test enables log collection to verify the functionality works correctly.

## Implementation Progress

This completes Phase 3 of the kecs-action roadmap:

- [x] **Phase 1**: Foundation and installation scripts
- [x] **Phase 2**: KECS startup and verification
- [x] **Phase 3**: Cleanup functionality (this PR)
- [ ] **Phase 4**: E2E testing
- [ ] **Phase 5**: Documentation and release preparation
- [ ] **Phase 6**: Dogfooding in KECS repository

## Benefits

1. **Guaranteed Cleanup**: Use with `if: always()` ensures cleanup even on test failures
2. **Debugging Support**: Log collection helps troubleshoot failing tests
3. **Resource Management**: Prevents orphaned k3d clusters in CI
4. **User-Friendly**: Simple, declarative cleanup step

## Next Steps

After merging:
1. Phase 4: E2E testing with real ECS workflows
2. Phase 5: Documentation and release preparation
3. Phase 6: Dogfooding in KECS repository CI

## Breaking Changes

None. This is an additive feature that enhances the action without changing existing functionality.